### PR TITLE
chore: reconcile seed.yaml + README + .gitignore with canonical reality

### DIFF
--- a/.claude/plans/2026-04-30-organ-wide-origin-audit.md
+++ b/.claude/plans/2026-04-30-organ-wide-origin-audit.md
@@ -1,0 +1,152 @@
+# 2026-04-30 — Organ-Wide Split-Origin Audit (PLAN STUB, NO EXECUTION)
+
+> **Status:** plan stub only. Captured while context is fresh during the
+> origin-unity follow-up session for `content-engine--asset-amplifier`. Do
+> not execute without explicit user direction — this is a 119-repo
+> coordination problem with policy questions that precede tooling.
+
+---
+
+## Context
+
+During the freshening of the origin-unity plan for
+`content-engine--asset-amplifier` on 2026-04-30, sampling 5 sibling repos in
+`~/Workspace/organvm/` revealed a systemic pattern:
+
+| Repo | Declared canonical (`seed.yaml.org`) | Actual `git remote origin` |
+| --- | --- | --- |
+| `content-engine--asset-amplifier` | `organvm-iii-ergon` | `organvm-iii-ergon` ← fixed this session |
+| `agentkit` | (TBD — not read) | `a-organvm` |
+| `analytics-engine` | `organvm-v-logos` | `a-organvm` |
+| `commerce--meta` | (TBD — not read) | `a-organvm` |
+| `community-hub` | (TBD — not read) | `a-organvm` |
+| `agentic-titan` | (TBD — not read) | `a-organvm` |
+
+5/5 sampled siblings have origins on the staging org `a-organvm`, despite
+their `seed.yaml` declaring canonical homes. With ~118 organvm/* repos,
+this is likely an organ-wide drift, not a per-repo accident.
+
+`content-engine--asset-amplifier` is now the first repo with origin
+pointing at canonical. The remaining ~118 are in the dual-origin state.
+
+---
+
+## What this audit needs to produce
+
+### 1. Full inventory
+
+For every repo under `~/Workspace/organvm/` (and equivalent for organ-I
+through organ-VII directories per the workspace CLAUDE.md map):
+
+```
+{
+  repo: "agentkit",
+  declared_org: "<from seed.yaml.org>",
+  declared_org_exists_on_github: true|false,
+  actual_origin: "a-organvm/agentkit",
+  canonical_repo_exists_on_github: true|false,
+  canonical_repo_default_branch: "main"|"feature/...",
+  promotion_status: "LOCAL"|"CANDIDATE"|...,
+  divergence: "none"|"staging-only"|"split"|"orphaned"
+}
+```
+
+Script shape:
+```bash
+for r in ~/Workspace/organvm/*/; do
+  pushd "$r" >/dev/null
+  declared=$(yq '.org' seed.yaml 2>/dev/null)
+  actual=$(git remote get-url origin 2>/dev/null)
+  status=$(yq '.metadata.promotion_status' seed.yaml 2>/dev/null)
+  echo "$(basename $r) declared=$declared actual=$actual status=$status"
+  popd >/dev/null
+done
+```
+
+### 2. Cross-reference with GitHub
+
+For each declared org found in the inventory:
+```bash
+gh repo list organvm-i-genesis --limit 100 --json name,visibility
+gh repo list organvm-ii-poiesis --limit 100 --json name,visibility
+gh repo list organvm-iii-ergon --limit 100 --json name,visibility
+gh repo list organvm-iv-taxis --limit 100 --json name,visibility
+gh repo list organvm-v-logos --limit 100 --json name,visibility
+gh repo list organvm-vi-koinonia --limit 100 --json name,visibility
+gh repo list organvm-vii-kerygma --limit 100 --json name,visibility
+gh repo list a-organvm --limit 200 --json name,visibility
+gh repo list meta-organvm --limit 100 --json name,visibility
+```
+
+Goal: which canonical repos exist? Are any private? Which have public
+content already? Which would be problematic to publicize?
+
+### 3. Decision matrix per repo
+
+For each repo, choose one of:
+- **Promote** — origin → declared canonical, push public, bump
+  `promotion_status`. Requires that the canonical org/repo exists and
+  the content is appropriate for public.
+- **Re-declare** — declared org in `seed.yaml` is wrong/aspirational;
+  rewrite `seed.yaml.org` to match `a-organvm`.
+- **Archive** — repo is dead; mark it ARCHIVED.
+- **Hold** — content needs review (secrets, partner code, NDA-bound work)
+  before publication decision.
+
+### 4. Promotion protocol design
+
+Per repo, the mechanical steps that follow `content-engine--asset-amplifier`'s
+pattern:
+```bash
+# Verify push permission on canonical
+gh api repos/<canonical-org>/<repo> --jq '.permissions'
+
+# Reconfigure remotes (local-only, reversible)
+git remote rename origin staging
+git remote add origin git@github.com:<canonical-org>/<repo>.git
+git fetch origin
+
+# Re-attach main, fast-forward push
+git branch --set-upstream-to=origin/main main
+git push origin main   # gated — needs PR if classifier blocks
+
+# Reconcile seed.yaml + README + .gitignore in same commit
+# (model after content-engine--asset-amplifier PR #21)
+```
+
+---
+
+## Risks
+
+- **Secret leak.** Any repo with hardcoded secrets, partner credentials,
+  or NDA content cannot be promoted to a public canonical org. Pre-flight
+  with `gitleaks` per repo before any push.
+- **Org-permissions mismatch.** The user may not have `admin:write` on
+  every declared canonical org. Per-repo `gh api repos/.../permissions`
+  check is mandatory.
+- **History exposure.** Even if current `main` is clean, deep git history
+  may contain things you don't want public. `git log --all -p | gitleaks
+  detect --pipe` per repo before promotion.
+- **Cross-repo dependency drift.** If repo A was importing from
+  `a-organvm/B` and B promotes to `organvm-iii-ergon/B`, A's lockfiles
+  may break. Inventory must capture cross-repo edges before batch
+  execution.
+- **Workspace CLAUDE.md drift.** The workspace CLAUDE.md says
+  `organvm-iii-ergon/` directory maps to GitHub org `labores-profani-crux`,
+  but this repo's actual origin is `organvm-iii-ergon`. The CLAUDE.md
+  table may be outdated. Audit must reconcile the table with on-disk
+  reality before any batch action.
+
+---
+
+## What this stub is not
+
+- Not a sequenced execution plan. The decision matrix is the gate.
+- Not a script. Code shapes above are illustrative; production audit
+  needs a real Python/Bash module under `meta-organvm/scripts/`.
+- Not a prediction of how many repos should be public. That's a policy
+  question for the user.
+
+---
+
+## Status: STUB. Do not execute. Read first when ready to scope the campaign.

--- a/.claude/plans/2026-04-30-origin-unity-followup.md
+++ b/.claude/plans/2026-04-30-origin-unity-followup.md
@@ -1,0 +1,118 @@
+# 2026-04-30 — Origin Unity Follow-up + Systemic Audit Surface
+
+> **Mirror.** Source of truth lives at
+> `~/.claude/plans/our-previous-session-s-work-witty-bubble.md`. Per global
+> CLAUDE.md plan discipline, plans devised in a project must be persisted in
+> that project. This file is the project-local sculpture.
+
+---
+
+## Context
+
+The prior session designed a 5-step plan to reconcile a "split origin" — the
+repo's `origin` pointed at a private staging clone (`a-organvm/...`), while
+`seed.yaml`, the project board, and `CLAUDE.md` declared the canonical home
+as `organvm-iii-ergon/...`. The session was blocked by the auto-mode
+classifier on the public push (Step 3) and ended awaiting explicit
+confirmation.
+
+This freshening session re-verified state against current disk and discovered:
+
+1. **The push completed.** `local main = origin/main = 5a55816ee9c2`. A
+   subsequent commit `5a55816 docs: add formation closure governance sequence`
+   was added on top (372 lines across 3 docs files). Steps 1-3 of the prior
+   plan are DONE.
+2. **One additional layer of context** the prior plan didn't have: sampling
+   5 sibling repos in `~/Workspace/organvm/` (agentkit, analytics-engine,
+   commerce--meta, community-hub, agentic-titan) shows **all 5** have
+   `origin → a-organvm/...` despite declaring canonical orgs in their
+   `seed.yaml`. The dual-origin pathology is systemic across the organ
+   ecosystem — `content-engine--asset-amplifier` is the **first repo** with
+   origin pointed at canonical, not the only one that needed it.
+
+This repo's remaining work is small. The organ-wide implication is large
+but out of scope for this plan — flagged as IRF + plan stub
+(`2026-04-30-organ-wide-origin-audit.md` in this directory).
+
+---
+
+## State verified (2026-04-30)
+
+| Item | Verified value |
+| --- | --- |
+| `local main` | `5a55816ee9c2` (HEAD) |
+| `origin/main` (organvm-iii-ergon, public) | `5a55816ee9c2` (in sync) |
+| `local feature/stripe-checkout` | `5c3ed9ef3a0a` (1 commit behind main) |
+| `staging/feature/stripe-checkout` (a-organvm, private) | `5c3ed9ef3a0a` (in sync) |
+| `staging/main` | does not exist |
+| `origin/feature/stripe-checkout` | does not exist |
+| `.conductor/active-handoff.md` | absent (no cross-verify pending) |
+| Untracked dirs | `.lh/`, `.specstory/`, `.vscode/` (tooling state) |
+| Sampled-sibling origins | 5/5 still on `a-organvm/...` |
+
+---
+
+## Decisions (resolved with user)
+
+1. **Branch retention** — keep both local and staging copies of
+   `feature/stripe-checkout`. No deletions. Branches are sculpture, same as
+   plans and atoms; "tidiness" doesn't override the sculpture rule.
+2. **Vacuum granularity** — single commit reconciling `seed.yaml`,
+   `README.md`, and `.gitignore`. State machine compliance: `LOCAL →
+   CANDIDATE` (next legal step), not `LOCAL → PUBLIC_PROCESS` (skip).
+3. **README scope** — extended beyond line 37 because the entire Stack
+   section was internally inconsistent and `CLAUDE.md` is authoritative on
+   the dual-runtime architecture. Single section, single edit unit.
+4. **Systemic surface** — IRF row at
+   `meta-organvm/.../INST-INDEX-RERUM-FACIENDARUM.md` + plan stub at
+   `2026-04-30-organ-wide-origin-audit.md` (no execution).
+5. **PR vs direct-to-main** — feature branch + PR (the harness's own
+   implied-by-classifier path). Path was chosen after the user reframed
+   the deferral as "energy-expense laziness" rather than "illogical-
+   targeted force." Direct-to-main was gated; PR satisfies the gate's
+   actual rationale (review surface).
+
+---
+
+## Critical files (this PR)
+
+- `seed.yaml` — `promotion_status: LOCAL → CANDIDATE`,
+  `last_validated: → "2026-04-30"`
+- `README.md` lines 30, 37-43 — Stack section reconciled with `CLAUDE.md`
+- `.gitignore` — appended `.lh/`, `.specstory/`, `.vscode/`
+- `.claude/plans/2026-04-30-origin-unity-followup.md` — this file
+- `.claude/plans/2026-04-30-organ-wide-origin-audit.md` — companion
+  audit plan stub (no execution)
+
+---
+
+## What was NOT done
+
+- No deletions anywhere. Branches, refs, files, remotes all intact.
+- No touch to the ~118 sibling repos. Surface only (IRF + stub).
+- Staging repo (`a-organvm/content-engine--asset-amplifier`) untouched.
+  `feature/stripe-checkout` remains at `5c3ed9e` on staging as a
+  historical receipt of the Stripe integration's transit through
+  staging.
+- No force-push. Every push fast-forwards.
+- No rewrite of the prior session's plan file. It accurately documents
+  what was true at its time of writing.
+
+---
+
+## Verification
+
+Branch retention check (no deletion expected):
+```bash
+git branch -vv | grep feature/stripe-checkout
+# expected: present at 5c3ed9e, tracking staging/feature/stripe-checkout
+git ls-remote --heads staging feature/stripe-checkout
+# expected: present at 5c3ed9e
+```
+
+After PR merge:
+```bash
+gh api repos/organvm-iii-ergon/content-engine--asset-amplifier/contents/seed.yaml \
+  --jq '.content' | base64 -d | grep -E 'promotion_status|last_validated'
+# expected: CANDIDATE, 2026-04-30
+```

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ dist/
 coverage/
 *.tsbuildinfo
 .keys.enc.json
+
+# Local tooling state (editor / session-capture)
+.lh/
+.specstory/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -27,20 +27,20 @@ Premium brands pay $15-50K for hero films and product renders. These assets get 
 
 ## Architecture (pnpm monorepo)
 
-- **apps/**: Next.js dashboard, Fastify API, Management CLI.
+- **apps/**: React dashboard, dual-runtime API (Cloudflare Worker + Fastify), Management CLI.
 - **services/**: Specialized microservices for ingestion, extraction, and generation.
 - **packages/**: Shared logic for Database (Drizzle), Domain, Storage (R2), Queues (BullMQ/Temporal).
 - **infra/**: Dockerized Redis/Postgres, Temporal configuration.
 
 ## Stack
 
-- **Frontend:** Next.js 15, React 19, Tailwind, Lucide.
-- **Backend:** Node.js/TypeScript (Fastify).
+- **Frontend:** React 19 + Vite 8 + Tailwind 3 + Lucide.
+- **Backend:** Node.js/TypeScript — dual-runtime API: Hono on Cloudflare Worker (production) + Fastify locally (full pipeline). See `CLAUDE.md` → Architecture: Dual-Runtime API.
 - **Database:** PostgreSQL (Neon) via Drizzle ORM.
 - **Workflow:** Temporal.io for retriable processing pipelines.
 - **Queue:** BullMQ + Redis.
 - **AI/ML:** FFmpeg, PySceneDetect, Whisper/Deepgram, Claude API.
-- **Deploy:** Vercel (frontend) + Railway/Render (services).
+- **Deploy:** Cloudflare Pages (dashboard) + Cloudflare Worker (API).
 
 ## Quick Start
 

--- a/seed.yaml
+++ b/seed.yaml
@@ -7,8 +7,8 @@ org: organvm-iii-ergon
 metadata:
   implementation_status: ACTIVE
   tier: standard
-  promotion_status: LOCAL
-  last_validated: "2026-03-26"
+  promotion_status: CANDIDATE
+  last_validated: "2026-04-30"
   generated: "2026-03-23"
   sprint: 1
 


### PR DESCRIPTION
## Summary

Three small reconciliations bringing committed metadata in line with what
the repo actually is now that origin points at canonical
`organvm-iii-ergon/content-engine--asset-amplifier`:

- **`seed.yaml`** — `promotion_status: LOCAL` → `CANDIDATE` and
  `last_validated: 2026-03-26` → `2026-04-30`. Per workspace promotion
  state machine (`LOCAL → CANDIDATE → PUBLIC_PROCESS → GRADUATED →
  ARCHIVED`, no state skipping), CANDIDATE is the next legal step.
  CANDIDATE is also accurate: origin was just unified to canonical this
  session, and the repo is ready for review (not yet at PUBLIC_PROCESS).
- **`README.md`** Stack section — brought into agreement with `CLAUDE.md`
  "Architecture: Dual-Runtime API". Frontend was misstated as Next.js 15
  (reality, verified against `apps/dashboard/package.json`: React 19 +
  Vite 8 + Tailwind 3 + Lucide; no `next` dependency). Backend now
  describes the Hono-on-Worker + Fastify-locally split. Deploy reflects
  Cloudflare Pages + Worker (not Vercel + Railway/Render). The
  `apps/` description on line 30 was updated to match.
- **`.gitignore`** — appended `.lh/`, `.specstory/`, `.vscode/`. These are
  local editor / session-capture state, currently untracked and noisy in
  `git status`.

No code changes. No deletions of existing branches, refs, or files.

## Why this PR shape (not direct-to-main)

The change set is small enough to land on `main` directly, but the
session-level guard correctly flagged that direct pushes to canonical
default branch bypass review. This PR exists as the explicit review
surface so the state-machine choice (CANDIDATE vs PUBLIC_PROCESS) and
the README scope expansion can be inspected before merging.

## Test plan

- [ ] `seed.yaml` parses (it's a single-document YAML — visual check
      sufficient; `python -c "import yaml; yaml.safe_load(open('seed.yaml'))"` if paranoid)
- [ ] `README.md` Stack section reads coherently end-to-end and references
      `CLAUDE.md` for the dual-runtime detail
- [ ] `.gitignore` ordering is logical (existing entries untouched, new
      entries grouped under a section comment)
- [ ] After merge: `git status` no longer shows `.lh/`, `.specstory/`,
      `.vscode/` as untracked

## Linked context

- Plan file: `.claude/plans/our-previous-session-s-work-witty-bubble.md`
  (the freshening session's design)
- Prior commit `5a55816 docs: add formation closure governance sequence`
  set canonical `main`; this PR sits cleanly on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update project metadata and documentation to reflect the current dual-runtime architecture and deployment setup while aligning repository status with canonical reality.

Enhancements:
- Revise README architecture and stack descriptions to describe the React/Vite dashboard, dual-runtime API, and Cloudflare-based deployment.
- Update seed.yaml metadata to mark the workspace as CANDIDATE with a refreshed validation date.
- Extend .gitignore to exclude local editor and session-capture directories from version control.